### PR TITLE
fix: nested nodes have type preventing proper nesting

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -2,10 +2,12 @@ use stretch2::prelude::*;
 
 fn main() -> Result<(), Error> {
     let mut stretch = Stretch::new();
+
     let child = stretch.new_node(
         Style { size: Size { width: Dimension::Percent(0.5), height: Dimension::Auto }, ..Default::default() },
         &[],
     )?;
+
     let node = stretch.new_node(
         Style {
             size: Size { width: Dimension::Points(100.0), height: Dimension::Points(100.0) },
@@ -15,7 +17,11 @@ fn main() -> Result<(), Error> {
         &[child],
     )?;
 
-    stretch.compute_layout(node, Size::undefined())?;
+    stretch.compute_layout(node, Size { height: Number::Defined(100.0), width: Number::Defined(100.0) })?;
+
+    // or just use undefined for 100 x 100
+    // stretch.compute_layout(node, Size::undefined())?;
+
     println!("node: {:#?}", stretch.layout(node)?);
     println!("child: {:#?}", stretch.layout(child)?);
 

--- a/examples/nested.rs
+++ b/examples/nested.rs
@@ -1,0 +1,52 @@
+use stretch2::prelude::*;
+
+fn main() -> Result<(), Error> {
+    let mut stretch = Stretch::new();
+
+    // left
+    let child_t1 = stretch.new_node(
+        Style { size: Size { width: Dimension::Points(5.0), height: Dimension::Points(5.0) }, ..Default::default() },
+        &[],
+    )?;
+
+    let div1 = stretch.new_node(
+        Style {
+            size: Size { width: Dimension::Percent(0.5), height: Dimension::Percent(1.0) },
+            // justify_content: JustifyContent::Center,
+            ..Default::default()
+        },
+        &[child_t1],
+    )?;
+
+    // right
+    let child_t2 = stretch.new_node(
+        Style { size: Size { width: Dimension::Points(5.0), height: Dimension::Points(5.0) }, ..Default::default() },
+        &[],
+    )?;
+
+    let div2 = stretch.new_node(
+        Style {
+            size: Size { width: Dimension::Percent(0.5), height: Dimension::Percent(1.0) },
+            // justify_content: JustifyContent::Center,
+            ..Default::default()
+        },
+        &[child_t2],
+    )?;
+
+    let container = stretch.new_node(
+        Style { size: Size { width: Dimension::Percent(1.0), height: Dimension::Percent(1.0) }, ..Default::default() },
+        &[div1, div2],
+    )?;
+
+    stretch.compute_layout(container, Size { height: Number::Defined(100.0), width: Number::Defined(100.0) })?;
+
+    println!("node: {:#?}", stretch.layout(container)?);
+
+    println!("div1: {:#?}", stretch.layout(div1)?);
+    println!("div2: {:#?}", stretch.layout(div2)?);
+
+    println!("child1: {:#?}", stretch.layout(child_t1)?);
+    println!("child2: {:#?}", stretch.layout(child_t2)?);
+
+    Ok(())
+}

--- a/src/algo.rs
+++ b/src/algo.rs
@@ -105,13 +105,12 @@ impl Forest {
         let abs_x = abs_x + layout.location.x;
         let abs_y = abs_y + layout.location.y;
 
-        // layout.location.x = sys::round(layout.location.x);
-        // layout.location.y = sys::round(layout.location.y);
         layout.location.x = sys::round(abs_x);
         layout.location.y = sys::round(abs_y);
 
         layout.size.width = sys::round(abs_x + layout.size.width) - sys::round(abs_x);
         layout.size.height = sys::round(abs_y + layout.size.height) - sys::round(abs_y);
+        
         for child in &children[root] {
             Self::round_layout(nodes, children, *child, abs_x, abs_y);
         }

--- a/src/algo.rs
+++ b/src/algo.rs
@@ -105,8 +105,11 @@ impl Forest {
         let abs_x = abs_x + layout.location.x;
         let abs_y = abs_y + layout.location.y;
 
-        layout.location.x = sys::round(layout.location.x);
-        layout.location.y = sys::round(layout.location.y);
+        // layout.location.x = sys::round(layout.location.x);
+        // layout.location.y = sys::round(layout.location.y);
+        layout.location.x = sys::round(abs_x);
+        layout.location.y = sys::round(abs_y);
+
         layout.size.width = sys::round(abs_x + layout.size.width) - sys::round(abs_x);
         layout.size.height = sys::round(abs_y + layout.size.height) - sys::round(abs_y);
         for child in &children[root] {


### PR DESCRIPTION
This integrates https://github.com/vislyhq/stretch/pull/87 to fix nested nodes.

Let's try to add some more documentation to this crate if we can. It's pretty opaque to use.